### PR TITLE
Improve Command line options

### DIFF
--- a/lib/guard/maven.rb
+++ b/lib/guard/maven.rb
@@ -121,6 +121,7 @@ module Guard
       # output as well as diplay it in terminal
       output = []
       IO.popen(cmds.join(' ')).each do |line|
+        line.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
         if @options[:verbose]
           puts line.chomp
         else

--- a/lib/guard/maven.rb
+++ b/lib/guard/maven.rb
@@ -107,7 +107,7 @@ module Guard
     end
 
     def run_maven_tests(options={})
-      cmds = ['mvn', 'clean', 'test']
+      cmds = ['mvn', 'test', '-DfailIfNoTests=false']
 
       if options[:classes]
         cmds << "-Dtest=#{options[:classes].join(',')}"


### PR DESCRIPTION
Don't clean before test, don't fail if a subproject doesn't have any tests.  

I would rather have to manually run a clean when I need it and get faster feedback on my tests for TDD.  