### PR TITLE
Use maven-cli for faster maven round-trips

### DIFF
--- a/guard-maven.gemspec
+++ b/guard-maven.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'guard', '~> 1.8.2'
+  spec.add_dependency 'guard-compat', '~> 1.1'
+  spec.add_dependency 'childprocess', '~> 0.5.5'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/guard/maven.rb
+++ b/lib/guard/maven.rb
@@ -44,7 +44,6 @@ module Guard
       # Wait until cli has started and opened socket access.
       while true
         line = @cliOut.readline
-        puts line
         break if line.match(/Waiting for commands/)
       end
       Compat::UI.info "Maven CLI has started"


### PR DESCRIPTION
This PR represents a few things. The biggest change here is to start up a [maven-cli](https://github.com/jdoklovic/maven-cli-plugin) long running process, and then interact with it whenever maven executions are needed. Maven has a 2-3 second startup penalty, so this dramatically cuts down the time it takes to run simple goals on a small-ish module.

This PR also changes the GEM to use guard-compat so it works with Guard 1.x and 2.x.

Finally, this PR adds support to define which goals you run when something changes. e.g

``` ruby
guard :maven, all_on_start: true, verbose: true, goals: ['install'] do
  watch(%r[src/.*/.*/(.*)\.java$]) { "all" }
end
```
